### PR TITLE
removes outline on help icon

### DIFF
--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -35,6 +35,7 @@
     tr: '',
     td: '',
     cell: '',
+    helpButton: '',
     paginationContainer: '',
     paginationInfo: '',
     paginationButtons: ''
@@ -142,7 +143,7 @@
 
             {#if col.helpModal}
               <button
-                class="text-blue-700 no-outline"
+                class={styles.helpButton}
                 type="button"
                 on:click={() => (activeModal = col.helpModal)}
               >

--- a/src/SvelteTable.svelte
+++ b/src/SvelteTable.svelte
@@ -142,7 +142,7 @@
 
             {#if col.helpModal}
               <button
-                class="text-blue-700"
+                class="text-blue-700 no-outline"
                 type="button"
                 on:click={() => (activeModal = col.helpModal)}
               >


### PR DESCRIPTION
When clicked, the help icon no longer leaves a black outline after the mouse has moved away. 